### PR TITLE
feat: support checking messages against multiple conditions

### DIFF
--- a/listeners/query-todays-lunch.js
+++ b/listeners/query-todays-lunch.js
@@ -12,28 +12,23 @@ module.exports = ({
       text
     } = message;
 
-    console.log('checking using text...', text);
-
     const isNotBotUser = Boolean(message.subtype !== 'bot_message');
     const isNotOwnMessage = message.user !== rtm.activeUserId;
 
-    const checks = [
+    const isTrue = result => result === true;
+    const isInteraction = [
       /!lunch/ig.test(text),
       /what.{1}s for lunch/ig.test(text),
       /what is for lunch/ig.test(text),
       /what is today.{1}s lunch/ig.test(text),
       /what.{1}s for lunch/ig.test(text)
-    ];
+    ].some(isTrue);
 
-    const isTrue = result => result === true;
-    const isInteraction = checks.some(isTrue);
-
-    const shouldRespondChecks = [
+    const shouldRespond = [
       isNotBotUser,
       isNotOwnMessage,
       isInteraction
-    ];
-    const shouldRespond = shouldRespondChecks.every(isTrue);
+    ].every(isTrue);
 
     if (!shouldRespond) {
       return null;

--- a/listeners/query-todays-lunch.js
+++ b/listeners/query-todays-lunch.js
@@ -5,26 +5,37 @@ module.exports = ({
   action,
   appState
 }) => {
-  const {
-    clients: { rtm },
-    subscribedChannels
-  } = appState;
-
+  const { clients: { rtm } } = appState;
   rtm.on('message', async message => {
     const {
       channel,
       text
     } = message;
 
-    const isBotUser = Boolean(message.subtype && message.subtype === 'bot_message');
-    const isOwnMessage = message.user === rtm.activeUserId;
+    console.log('checking using text...', text);
 
-    if (!isBotUser && isOwnMessage) {
-      return null;
-    }
+    const isNotBotUser = Boolean(message.subtype !== 'bot_message');
+    const isNotOwnMessage = message.user !== rtm.activeUserId;
 
-    const isInteraction = text.match(/!lunch/g);
-    if (!subscribedChannels[channel] || !isInteraction) {
+    const checks = [
+      /!lunch/ig.test(text),
+      /what.{1}s for lunch/ig.test(text),
+      /what is for lunch/ig.test(text),
+      /what is today.{1}s lunch/ig.test(text),
+      /what.{1}s for lunch/ig.test(text)
+    ];
+
+    const isTrue = result => result === true;
+    const isInteraction = checks.some(isTrue);
+
+    const shouldRespondChecks = [
+      isNotBotUser,
+      isNotOwnMessage,
+      isInteraction
+    ];
+    const shouldRespond = shouldRespondChecks.every(isTrue);
+
+    if (!shouldRespond) {
       return null;
     }
 

--- a/listeners/query-todays-lunch.test.js
+++ b/listeners/query-todays-lunch.test.js
@@ -1,14 +1,18 @@
 import proxyquire from 'proxyquire';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import test from 'ava';
 
 import channelFixture from '../_fixtures/channel.fixture';
 
-const stubAction = sinon.stub().resolves({});
-const stubLogger = { debug: sinon.stub() };
-const stubTracker = { track: sinon.stub() };
+const sandbox = createSandbox();
+const mockResult = { result: 'success' };
+const stubAction = sandbox.stub().resolves(mockResult);
+const stubLogger = { debug: sandbox.stub() };
+const stubTracker = { track: sandbox.stub() };
 
+const mockRTMClient = { activeUserId: '999', on: sandbox.stub() };
 const mockSubscribedChannels = { CD93G4JMP: channelFixture };
+
 const queryTodaysLunch = proxyquire
   .noCallThru()
   .load('./query-todays-lunch', {
@@ -19,10 +23,7 @@ const queryTodaysLunch = proxyquire
 const getAppState = () => {
   return {
     clients: {
-      rtm: {
-        activeUserId: '999',
-        on: sinon.stub()
-      }
+      rtm: mockRTMClient
     },
     subscribedChannels: mockSubscribedChannels
   };
@@ -35,14 +36,50 @@ const mockValidMessage = {
   user: '10001'
 };
 
-test('it subscribes to the RTM client\'s "message" events', t => {
+test.afterEach.always('resetting stubs', () => {
+  sandbox.resetHistory();
+});
+
+test.serial('it subscribes to the RTM client\'s "message" events', t => {
   const appState = getAppState();
   const { clients: { rtm } } = appState;
   queryTodaysLunch({ action: stubAction, appState });
   t.deepEqual(rtm.on.args[0][0], 'message');
+  t.is(typeof rtm.on.args[0][1], 'function');
 });
 
-test('it fires a tracking event for valid interaction messages', async t => {
+test.serial('it calls some action for valid interaction messages', async t => {
+  const appState = getAppState();
+  const { clients: { rtm } } = appState;
+  queryTodaysLunch({ action: stubAction, appState });
+  const messageHandler = rtm.on.args[0][1];
+  await messageHandler(mockValidMessage);
+  t.deepEqual(stubAction.args, [
+    [
+      { appState, message: mockValidMessage }
+    ]
+  ]);
+});
+
+test.serial('it ignores its own messages', async t => {
+  const appState = getAppState();
+  const { clients: { rtm } } = appState;
+  queryTodaysLunch({ action: stubAction, appState });
+  const messageHandler = rtm.on.args[0][1];
+  await messageHandler({ ...mockValidMessage, user: rtm.activeUserId });
+  t.deepEqual(stubAction.args, []);
+});
+
+test.serial('it ignores messages from bots', async t => {
+  const appState = getAppState();
+  const { clients: { rtm } } = appState;
+  queryTodaysLunch({ action: stubAction, appState });
+  const messageHandler = rtm.on.args[0][1];
+  await messageHandler({ ...mockValidMessage, subtype: 'bot_message' });
+  t.deepEqual(stubAction.args, []);
+});
+
+test.serial('it fires a tracking event for valid interaction messages', async t => {
   const appState = getAppState();
   const { clients: { rtm } } = appState;
   queryTodaysLunch({ action: stubAction, appState });


### PR DESCRIPTION
This PR refactors the `QUERY_TODAYS_LUNCH` listener to check for multiple phrases to determine if a message is a valid interaction.